### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/pablosilvajorquera/46b6b29c-3255-4ab3-b8b7-06893d60e133/8f7e136d-c131-4e1d-8744-c3d5d67d60f2/_apis/work/boardbadge/fb5ad0b3-e5ab-40cf-b86e-c2c74a3ee947)](https://dev.azure.com/pablosilvajorquera/46b6b29c-3255-4ab3-b8b7-06893d60e133/_boards/board/t/8f7e136d-c131-4e1d-8744-c3d5d67d60f2/Microsoft.RequirementCategory)
 # PrimerDevops


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#159](https://dev.azure.com/pablosilvajorquera/46b6b29c-3255-4ab3-b8b7-06893d60e133/_workitems/edit/159). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.